### PR TITLE
Ajout de la baseline en dessous du logo

### DIFF
--- a/lib/public/components/PublicHeader.js
+++ b/lib/public/components/PublicHeader.js
@@ -23,7 +23,10 @@ export default class PublicHeader extends Component {
         {/* Title Column */}
         <Col xs={6}>
         {isExtensionEnabled('datagouvfr') ?
-          <img src="/lib/assets/logo_datagouvfr.svg" width="90%"/> :
+            <div class="logo">
+              <img src="/lib/assets/logo_datagouvfr.svg"/><br/>
+              <span>Rendre disponible, valoriser et améliorer les données transports</span>
+            </div>:
           <h1 style={{ marginTop: 0 }}>{this.props.title}</h1>
         }
         </Col>

--- a/lib/style.css
+++ b/lib/style.css
@@ -201,3 +201,13 @@ h4.line:after {
   max-height: 400px;
   overflow-x: hidden;
 }
+
+.logo span {
+    font-style: italic;
+    margin-left: 0.2em;
+    font-size: 17px;
+}
+
+.logo img {
+    width: 80%;
+}


### PR DESCRIPTION
Résultat
![datatools-ui-baseline](https://user-images.githubusercontent.com/2757318/28718926-509f790a-73a8-11e7-8246-13c034ed5281.png)
fixes #65 